### PR TITLE
Update docker-compose.yml

### DIFF
--- a/templates/apachenifi/0/docker-compose.yml
+++ b/templates/apachenifi/0/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2"
 
 services:
   zookeeper:  # the configuration manager


### PR DESCRIPTION
loopedge marketplace doesn't support `version: 3` yet.
change it to `version: 2`